### PR TITLE
Publish IOS simulator variant

### DIFF
--- a/deeplink/build.gradle.kts
+++ b/deeplink/build.gradle.kts
@@ -35,6 +35,11 @@ kotlin {
             framework(listOf(RELEASE))
         }
     }
+    iosSimulatorArm64("iosSimulatorArm64") {
+        binaries {
+            framework(listOf(DEBUG))
+        }
+    }
 
     jvm {
         compilations.all {
@@ -92,17 +97,21 @@ kotlin {
         }
         val iosX64Main by sourceSets.getting
         val iosArm64Main by sourceSets.getting
+        val iosSimulatorArm64Main by sourceSets.getting
         val iosMain by sourceSets.creating {
             dependsOn(commonMain)
             iosX64Main.dependsOn(this)
             iosArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
         }
         val iosX64Test by sourceSets.getting
         val iosArm64Test by sourceSets.getting
+        val iosSimulatorArm64Test by sourceSets.getting
         val iosTest by sourceSets.creating {
             dependsOn(commonTest)
             iosX64Test.dependsOn(this)
             iosArm64Test.dependsOn(this)
+            iosSimulatorArm64Test.dependsOn(this)
         }
         val jvmMain by getting
         val jvmTest by getting {

--- a/mocks/build.gradle.kts
+++ b/mocks/build.gradle.kts
@@ -29,6 +29,11 @@ kotlin {
             framework(listOf(RELEASE))
         }
     }
+    iosSimulatorArm64("iosSimulatorArm64") {
+        binaries {
+            framework(listOf(DEBUG))
+        }
+    }
 
     jvm {
         compilations.all {
@@ -84,17 +89,21 @@ kotlin {
         }
         val iosX64Main by sourceSets.getting
         val iosArm64Main by sourceSets.getting
+        val iosSimulatorArm64Main by sourceSets.getting
         val iosMain by sourceSets.creating {
             dependsOn(commonMain)
             iosX64Main.dependsOn(this)
             iosArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
         }
         val iosX64Test by sourceSets.getting
         val iosArm64Test by sourceSets.getting
+        val iosSimulatorArm64Test by sourceSets.getting
         val iosTest by sourceSets.creating {
             dependsOn(commonTest)
             iosX64Test.dependsOn(this)
             iosArm64Test.dependsOn(this)
+            iosSimulatorArm64Test.dependsOn(this)
         }
         val jvmMain by getting
         val jvmTest by getting {

--- a/push/build.gradle.kts
+++ b/push/build.gradle.kts
@@ -35,6 +35,11 @@ kotlin {
             framework(listOf(RELEASE))
         }
     }
+    iosSimulatorArm64("iosSimulatorArm64") {
+        binaries {
+            framework(listOf(DEBUG))
+        }
+    }
 
     jvm {
         compilations.all {
@@ -90,17 +95,21 @@ kotlin {
         }
         val iosX64Main by sourceSets.getting
         val iosArm64Main by sourceSets.getting
+        val iosSimulatorArm64Main by sourceSets.getting
         val iosMain by sourceSets.creating {
             dependsOn(commonMain)
             iosX64Main.dependsOn(this)
             iosArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
         }
         val iosX64Test by sourceSets.getting
         val iosArm64Test by sourceSets.getting
+        val iosSimulatorArm64Test by sourceSets.getting
         val iosTest by sourceSets.creating {
             dependsOn(commonTest)
             iosX64Test.dependsOn(this)
             iosArm64Test.dependsOn(this)
+            iosSimulatorArm64Test.dependsOn(this)
         }
         val jvmMain by getting
         val jvmTest by getting {

--- a/testaction/build.gradle.kts
+++ b/testaction/build.gradle.kts
@@ -33,6 +33,11 @@ kotlin {
             framework(listOf(RELEASE))
         }
     }
+    iosSimulatorArm64("iosSimulatorArm64") {
+        binaries {
+            framework(listOf(DEBUG))
+        }
+    }
     val outputIos by tasks.creating(org.jetbrains.kotlin.gradle.tasks.FatFrameworkTask::class) {
         group = "output"
         destinationDir = file("$projectDir/output/ios/Fat")
@@ -114,17 +119,21 @@ kotlin {
         }
         val iosX64Main by sourceSets.getting
         val iosArm64Main by sourceSets.getting
+        val iosSimulatorArm64Main by sourceSets.getting
         val iosMain by sourceSets.creating {
             dependsOn(commonMain)
             iosX64Main.dependsOn(this)
             iosArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
         }
         val iosX64Test by sourceSets.getting
         val iosArm64Test by sourceSets.getting
+        val iosSimulatorArm64Test by sourceSets.getting
         val iosTest by sourceSets.creating {
             dependsOn(commonTest)
             iosX64Test.dependsOn(this)
             iosArm64Test.dependsOn(this)
+            iosSimulatorArm64Test.dependsOn(this)
         }
         val jvmMain by getting
         val jvmTest by getting {

--- a/uri/build.gradle.kts
+++ b/uri/build.gradle.kts
@@ -35,6 +35,11 @@ kotlin {
             framework(listOf(RELEASE, DEBUG))
         }
     }
+    iosSimulatorArm64("iosSimulatorArm64") {
+        binaries {
+            framework(listOf(DEBUG))
+        }
+    }
 
     jvm {
         compilations.all {
@@ -90,17 +95,21 @@ kotlin {
         }
         val iosX64Main by sourceSets.getting
         val iosArm64Main by sourceSets.getting
+        val iosSimulatorArm64Main by sourceSets.getting
         val iosMain by sourceSets.creating {
             dependsOn(commonMain)
             iosX64Main.dependsOn(this)
             iosArm64Main.dependsOn(this)
+            iosSimulatorArm64Main.dependsOn(this)
         }
         val iosX64Test by sourceSets.getting
         val iosArm64Test by sourceSets.getting
+        val iosSimulatorArm64Test by sourceSets.getting
         val iosTest by sourceSets.creating {
             dependsOn(commonTest)
             iosX64Test.dependsOn(this)
             iosArm64Test.dependsOn(this)
+            iosSimulatorArm64Test.dependsOn(this)
         }
         val jvmMain by getting
         val jvmTest by getting {

--- a/uri/src/iosMain/kotlin/com/motorro/keeplink/uri/uriTools.kt
+++ b/uri/src/iosMain/kotlin/com/motorro/keeplink/uri/uriTools.kt
@@ -100,7 +100,7 @@ private fun String.splitCombinedHost(): Pair<String?, Int> =
  * Builds path component
  */
 private fun Array<String>.toPath(): String? =
-    takeIf { it.isNotEmpty() }?.joinToString("/", "/")
+    takeIf { it.isNotEmpty() }?.joinToString("/", "/") ?: "/"
 
 /**
  * Joins search parameters to search string

--- a/uri/src/jsMain/kotlin/com/motorro/keeplink/uri/uriTools.kt
+++ b/uri/src/jsMain/kotlin/com/motorro/keeplink/uri/uriTools.kt
@@ -65,7 +65,7 @@ private fun String.toPathComponent(): Array<String> =
  * Builds path component
  */
 private fun Array<String>.toPath(): String =
-    joinToString("/", "/")
+    takeIf { it.isNotEmpty() }?.joinToString("/", "/") ?: "/"
 
 /**
  * Parses search parameters


### PR DESCRIPTION
This PR changes the build definition to publish a variant for the `iosSimulatorArm64` target.

* Fixes #2 

This enabled running all unit tests on CI for ios and uncovered a failing test.
This PR includes a commit to fix it.

I confirmed locally using an included build that the `iosSimulatorArm64` variant resolves correctly from an application and that I can run ios tests there.